### PR TITLE
Remove debugger require

### DIFF
--- a/lib/rails_stats.rb
+++ b/lib/rails_stats.rb
@@ -4,8 +4,6 @@ module RailsStats
 
 end
 
-require 'debugger'
-
 require 'rails_stats/inflector'
 require 'rails_stats/code_statistics_calculator'
 require 'rails_stats/util'


### PR DESCRIPTION
debugger doesn't seem to be an actual dependency and it doesn't work in ruby 2.0+
