### PR TITLE
Add dependency on bundler-stats and improve output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Build and run tests
         env:
           COVERAGE: true
+          TERM: xterm
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           gem install bundler
@@ -40,6 +41,7 @@ jobs:
       - name: Build and run tests
         env:
           COVERAGE: true
+          TERM: xterm
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           gem install bundler
@@ -58,6 +60,7 @@ jobs:
       - name: Build and run tests
         env:
           COVERAGE: true
+          TERM: xterm
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           gem install bundler
@@ -76,6 +79,7 @@ jobs:
       - name: Build and run tests
         env:
           COVERAGE: true
+          TERM: xterm
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           gem install bundler
@@ -94,6 +98,7 @@ jobs:
       - name: Build and run tests
         env:
           COVERAGE: true
+          TERM: xterm
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           gem install bundler

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,6 @@ on:
   pull_request:
     branches:
     - main
-env:
-  COVERAGE: true
-  CODECOV_TOKEN: d7028c0e-97c5-485f-85e5-f63daabeef63
 jobs:
   test-ruby-2-4-x:
     runs-on: ubuntu-latest
@@ -23,6 +20,9 @@ jobs:
           ruby-version: 2.4
           bundler-cache: true
       - name: Build and run tests
+        env:
+          COVERAGE: true
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           gem install bundler
           bundle install --jobs 4 --retry 3
@@ -38,6 +38,9 @@ jobs:
           ruby-version: 2.5
           bundler-cache: true
       - name: Build and run tests
+        env:
+          COVERAGE: true
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           gem install bundler
           bundle install --jobs 4 --retry 3
@@ -53,6 +56,9 @@ jobs:
           ruby-version: 2.6
           bundler-cache: true
       - name: Build and run tests
+        env:
+          COVERAGE: true
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           gem install bundler
           bundle install --jobs 4 --retry 3
@@ -68,6 +74,9 @@ jobs:
           ruby-version: 2.7
           bundler-cache: true
       - name: Build and run tests
+        env:
+          COVERAGE: true
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           gem install bundler
           bundle install --jobs 4 --retry 3
@@ -83,6 +92,9 @@ jobs:
           ruby-version: 3.0
           bundler-cache: true
       - name: Build and run tests
+        env:
+          COVERAGE: true
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           gem install bundler
           bundle install --jobs 4 --retry 3

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
+.byebug_history
 *.gem
 *.rbc
 .bundle
 .config
+.ruby-version
 .yardoc
 Gemfile.lock
 InstalledFiles

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,14 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-# Specify your gem's dependencies in rails_stats.gemspec
 gemspec
+
+group :development, :test do
+  gem "bundler", ">= 1.6", "< 3.0"
+  gem "byebug"
+  gem "codecov"
+  gem "minitest"
+  gem "minitest-around"
+  gem "minitest-spec-context"
+  gem "simplecov"
+  gem "simplecov-console"
+end

--- a/lib/rails_stats/app_statistics.rb
+++ b/lib/rails_stats/app_statistics.rb
@@ -3,10 +3,11 @@ module RailsStats
     attr_reader :statistics, :total, :test
 
     def initialize(directory)
+      @directories = []
       @test = false
-      @directory  = directory
-      @statistics = calculate_statistics
-      @total      = calculate_total
+      @directory   = directory
+      @statistics  = calculate_statistics
+      @total       = calculate_total
     end
 
     def key_concepts
@@ -28,15 +29,15 @@ module RailsStats
     end
 
     def directories
-      return @directories if @directories
-      out = []
+      return @directories if @directories.any?
+
       Dir.foreach(@directory) do |file_name|
         path = File.join(@directory, file_name)
         next unless File.directory?(path)
         next if (/^\./ =~ file_name)
         next if file_name == "assets" # doing separately
         next if file_name == "views"  # TODO
-        out << path
+        @directories << path
       end
 
       assets = File.join(@directory, "assets")
@@ -48,13 +49,13 @@ module RailsStats
 
           case file_name
           when "javascripts"
-            out << path
+            @directories << path
           # TODO when "css"
           end
         end
       end
 
-      out
+      @directories
     end
   end
 

--- a/lib/rails_stats/console_formatter.rb
+++ b/lib/rails_stats/console_formatter.rb
@@ -1,6 +1,10 @@
+require "bundler/stats/cli"
+
 module RailsStats
   class ConsoleFormatter < StatsFormatter
     def to_s
+      Bundler::Stats::CLI.start
+
       print_header
       sorted_keys = @statistics.keys.sort
       sorted_keys.each { |key| print_line(key, @statistics[key]) }

--- a/rails_stats.gemspec
+++ b/rails_stats.gemspec
@@ -20,12 +20,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rake"
   spec.add_dependency "bundler-stats", ">= 2.1"
-  spec.add_development_dependency "bundler", ">= 1.6", "< 3.0"
-  spec.add_development_dependency "byebug"
-  spec.add_development_dependency "codecov"
-  spec.add_development_dependency "minitest"
-  spec.add_development_dependency "minitest-around"
-  spec.add_development_dependency "minitest-spec-context"
-  spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "simplecov-console"
 end

--- a/rails_stats.gemspec
+++ b/rails_stats.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rake"
-  spec.add_dependency "bundler-stats", ">= 2.0"
+  spec.add_dependency "bundler-stats", ">= 2.1"
   spec.add_development_dependency "bundler", ">= 1.6", "< 3.0"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "codecov"

--- a/rails_stats.gemspec
+++ b/rails_stats.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rake"
+  spec.add_dependency "bundler-stats", ">= 2.0"
   spec.add_development_dependency "bundler", ">= 1.6", "< 3.0"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "codecov"

--- a/test/dummy/lib/monkeypatches.rb
+++ b/test/dummy/lib/monkeypatches.rb
@@ -1,0 +1,1 @@
+puts "Monkeypatches go here"

--- a/test/dummy/spec/models/user_spec.rb
+++ b/test/dummy/spec/models/user_spec.rb
@@ -1,0 +1,3 @@
+class FooBar
+
+end

--- a/test/dummy/spec/support/support_file.rb
+++ b/test/dummy/spec/support/support_file.rb
@@ -1,0 +1,1 @@
+puts "This is a spec support file"

--- a/test/dummy/test/models/user_test.rb
+++ b/test/dummy/test/models/user_test.rb
@@ -1,0 +1,2 @@
+class UserTest
+end

--- a/test/dummy/test/support/test_helper.rb
+++ b/test/dummy/test/support/test_helper.rb
@@ -1,0 +1,1 @@
+puts "This is a test support file"

--- a/test/lib/rails_stats/code_statistics_test.rb
+++ b/test/lib/rails_stats/code_statistics_test.rb
@@ -8,6 +8,40 @@ describe RailsStats::CodeStatistics do
 +-----------------------|------------|----------------+
 |                  Name | Total Deps | 1st Level Deps |
 +-----------------------|------------|----------------+
+|     simplecov-console | 7          | 3              |
+|               codecov | 4          | 1              |
+|           rails_stats | 4          | 2              |
+|             simplecov | 3          | 3              |
+|       minitest-around | 1          | 1              |
+|               bundler | 0          | 0              |
+|                byebug | 0          | 0              |
+|              minitest | 0          | 0              |
+| minitest-spec-context | 0          | 0              |
++-----------------------|------------|----------------+
+                          \n      Declared Gems   9   \n         Total Gems   17  \n  Unpinned Versions   8   \n        Github Refs   0   \n                          \n+----------------------+---------+---------+---------+---------+-----+-------+
+| Name                 | Lines   |     LOC | Classes | Methods | M/C | LOC/M |
++----------------------+---------+---------+---------+---------+-----+-------+
+| Channels             |       8 |       8 |       2 |       0 |   0 |     0 |
+| Configuration        |     417 |     111 |       1 |       0 |   0 |     0 |
+| Controllers          |       7 |       6 |       1 |       1 |   1 |     4 |
+| Helpers              |       3 |       3 |       0 |       0 |   0 |     0 |
+| Javascripts          |      27 |       7 |       0 |       0 |   0 |     0 |
+| Jobs                 |       7 |       2 |       1 |       0 |   0 |     0 |
+| Mailers              |       4 |       4 |       1 |       0 |   0 |     0 |
+| Models               |       3 |       3 |       1 |       0 |   0 |     0 |
++----------------------+---------+---------+---------+---------+-----+-------+
+| Code                 |     476 |     144 |       7 |       1 |   0 |   142 |
+| Tests                |       0 |       0 |       0 |       0 |   0 |     0 |
+| Total                |     476 |     144 |       7 |       1 |   0 |   142 |
++----------------------+---------+---------+---------+---------+-----+-------+
+  Code LOC: 144     Test LOC: 0     Code to Test Ratio: 1:0.0
+
+    EOS
+
+    TABLE_RUBY_2_4 = <<~EOS
++-----------------------|------------|----------------+
+|                  Name | Total Deps | 1st Level Deps |
++-----------------------|------------|----------------+
 |     simplecov-console | 6          | 3              |
 |           rails_stats | 4          | 2              |
 |               codecov | 3          | 1              |
@@ -45,7 +79,13 @@ EOS
         RailsStats::CodeStatistics.new(root_directory).to_s
       end
 
-      assert_equal TABLE, out
+      expectation = if RUBY_VERSION < "2.5.0"
+        TABLE_RUBY_2_4
+      else
+        TABLE
+      end
+
+      assert_equal expectation, out
     end
   end
 end

--- a/test/lib/rails_stats/code_statistics_test.rb
+++ b/test/lib/rails_stats/code_statistics_test.rb
@@ -27,14 +27,18 @@ describe RailsStats::CodeStatistics do
 | Helpers              |       3 |       3 |       0 |       0 |   0 |     0 |
 | Javascripts          |      27 |       7 |       0 |       0 |   0 |     0 |
 | Jobs                 |       7 |       2 |       1 |       0 |   0 |     0 |
+| Libraries            |       1 |       1 |       0 |       0 |   0 |     0 |
 | Mailers              |       4 |       4 |       1 |       0 |   0 |     0 |
+| Model Tests          |       5 |       4 |       2 |       0 |   0 |     0 |
 | Models               |       3 |       3 |       1 |       0 |   0 |     0 |
+| Spec Support         |       1 |       1 |       0 |       0 |   0 |     0 |
+| Test Support         |       1 |       1 |       0 |       0 |   0 |     0 |
 +----------------------+---------+---------+---------+---------+-----+-------+
-| Code                 |     476 |     144 |       7 |       1 |   0 |   142 |
-| Tests                |       0 |       0 |       0 |       0 |   0 |     0 |
-| Total                |     476 |     144 |       7 |       1 |   0 |   142 |
+| Code                 |     477 |     145 |       7 |       1 |   0 |   143 |
+| Tests                |       7 |       6 |       2 |       0 |   0 |     0 |
+| Total                |     484 |     151 |       9 |       1 |   0 |   149 |
 +----------------------+---------+---------+---------+---------+-----+-------+
-  Code LOC: 144     Test LOC: 0     Code to Test Ratio: 1:0.0
+  Code LOC: 145     Test LOC: 6     Code to Test Ratio: 1:0.0
 
     EOS
 
@@ -61,14 +65,18 @@ describe RailsStats::CodeStatistics do
 | Helpers              |       3 |       3 |       0 |       0 |   0 |     0 |
 | Javascripts          |      27 |       7 |       0 |       0 |   0 |     0 |
 | Jobs                 |       7 |       2 |       1 |       0 |   0 |     0 |
+| Libraries            |       1 |       1 |       0 |       0 |   0 |     0 |
 | Mailers              |       4 |       4 |       1 |       0 |   0 |     0 |
+| Model Tests          |       5 |       4 |       2 |       0 |   0 |     0 |
 | Models               |       3 |       3 |       1 |       0 |   0 |     0 |
+| Spec Support         |       1 |       1 |       0 |       0 |   0 |     0 |
+| Test Support         |       1 |       1 |       0 |       0 |   0 |     0 |
 +----------------------+---------+---------+---------+---------+-----+-------+
-| Code                 |     476 |     144 |       7 |       1 |   0 |   142 |
-| Tests                |       0 |       0 |       0 |       0 |   0 |     0 |
-| Total                |     476 |     144 |       7 |       1 |   0 |   142 |
+| Code                 |     477 |     145 |       7 |       1 |   0 |   143 |
+| Tests                |       7 |       6 |       2 |       0 |   0 |     0 |
+| Total                |     484 |     151 |       9 |       1 |   0 |   149 |
 +----------------------+---------+---------+---------+---------+-----+-------+
-  Code LOC: 144     Test LOC: 0     Code to Test Ratio: 1:0.0
+  Code LOC: 145     Test LOC: 6     Code to Test Ratio: 1:0.0
 
 EOS
 

--- a/test/lib/rails_stats/code_statistics_test.rb
+++ b/test/lib/rails_stats/code_statistics_test.rb
@@ -5,7 +5,20 @@ require "test_helper"
 describe RailsStats::CodeStatistics do
   describe "#to_s" do
     TABLE = <<~EOS
-+----------------------+---------+---------+---------+---------+-----+-------+
++-----------------------|------------|----------------+
+|                  Name | Total Deps | 1st Level Deps |
++-----------------------|------------|----------------+
+|     simplecov-console | 7          | 3              |
+|               codecov | 4          | 1              |
+|           rails_stats | 4          | 2              |
+|             simplecov | 3          | 3              |
+|       minitest-around | 1          | 1              |
+|              minitest | 0          | 0              |
+|               bundler | 0          | 0              |
+|                byebug | 0          | 0              |
+| minitest-spec-context | 0          | 0              |
++-----------------------|------------|----------------+
+                          \n      Declared Gems   9   \n         Total Gems   17  \n  Unpinned Versions   8   \n        Github Refs   0   \n                          \n+----------------------+---------+---------+---------+---------+-----+-------+
 | Name                 | Lines   |     LOC | Classes | Methods | M/C | LOC/M |
 +----------------------+---------+---------+---------+---------+-----+-------+
 | Channels             |       8 |       8 |       2 |       0 |   0 |     0 |
@@ -28,9 +41,11 @@ describe RailsStats::CodeStatistics do
     it "outputs useful stats for a Rails project" do
       root_directory = File.expand_path('../../../test/dummy', File.dirname(__FILE__))
 
-      assert_output(TABLE) do
+      out, err = capture_io do
         RailsStats::CodeStatistics.new(root_directory).to_s
       end
+
+      assert_equal TABLE, out
     end
   end
 end

--- a/test/lib/rails_stats/code_statistics_test.rb
+++ b/test/lib/rails_stats/code_statistics_test.rb
@@ -13,9 +13,9 @@ describe RailsStats::CodeStatistics do
 |           rails_stats | 4          | 2              |
 |             simplecov | 3          | 3              |
 |       minitest-around | 1          | 1              |
-|              minitest | 0          | 0              |
 |               bundler | 0          | 0              |
 |                byebug | 0          | 0              |
+|              minitest | 0          | 0              |
 | minitest-spec-context | 0          | 0              |
 +-----------------------|------------|----------------+
                           \n      Declared Gems   9   \n         Total Gems   17  \n  Unpinned Versions   8   \n        Github Refs   0   \n                          \n+----------------------+---------+---------+---------+---------+-----+-------+

--- a/test/lib/rails_stats/code_statistics_test.rb
+++ b/test/lib/rails_stats/code_statistics_test.rb
@@ -8,17 +8,17 @@ describe RailsStats::CodeStatistics do
 +-----------------------|------------|----------------+
 |                  Name | Total Deps | 1st Level Deps |
 +-----------------------|------------|----------------+
-|     simplecov-console | 7          | 3              |
-|               codecov | 4          | 1              |
+|     simplecov-console | 6          | 3              |
 |           rails_stats | 4          | 2              |
-|             simplecov | 3          | 3              |
+|               codecov | 3          | 1              |
+|             simplecov | 2          | 2              |
 |       minitest-around | 1          | 1              |
 |               bundler | 0          | 0              |
 |                byebug | 0          | 0              |
 |              minitest | 0          | 0              |
 | minitest-spec-context | 0          | 0              |
 +-----------------------|------------|----------------+
-                          \n      Declared Gems   9   \n         Total Gems   17  \n  Unpinned Versions   8   \n        Github Refs   0   \n                          \n+----------------------+---------+---------+---------+---------+-----+-------+
+                          \n      Declared Gems   9   \n         Total Gems   16  \n  Unpinned Versions   8   \n        Github Refs   0   \n                          \n+----------------------+---------+---------+---------+---------+-----+-------+
 | Name                 | Lines   |     LOC | Classes | Methods | M/C | LOC/M |
 +----------------------+---------+---------+---------+---------+-----+-------+
 | Channels             |       8 |       8 |       2 |       0 |   0 |     0 |
@@ -36,7 +36,7 @@ describe RailsStats::CodeStatistics do
 +----------------------+---------+---------+---------+---------+-----+-------+
   Code LOC: 144     Test LOC: 0     Code to Test Ratio: 1:0.0
 
-    EOS
+EOS
 
     it "outputs useful stats for a Rails project" do
       root_directory = File.expand_path('../../../test/dummy', File.dirname(__FILE__))

--- a/test/lib/rails_stats/json_formatter_test.rb
+++ b/test/lib/rails_stats/json_formatter_test.rb
@@ -6,10 +6,26 @@ describe RailsStats::JSONFormatter do
   describe "#result" do
     JSON_STRING = <<~EOS
     [{
+      "name": "Libraries",
+      "lines": "1",
+      "loc": "1",
+      "classes": "0",
+      "methods": "0",
+      "m_over_c": "0",
+      "loc_over_m": "0"
+    }, {
       "name": "Mailers",
       "lines": "4",
       "loc": "4",
       "classes": "1",
+      "methods": "0",
+      "m_over_c": "0",
+      "loc_over_m": "0"
+    }, {
+      "name": "Model Tests",
+      "lines": "5",
+      "loc": "4",
+      "classes": "2",
       "methods": "0",
       "m_over_c": "0",
       "loc_over_m": "0"
@@ -70,13 +86,29 @@ describe RailsStats::JSONFormatter do
       "m_over_c": "0",
       "loc_over_m": "0"
     }, {
+      "name": "Spec Support",
+      "lines": "1",
+      "loc": "1",
+      "classes": "0",
+      "methods": "0",
+      "m_over_c": "0",
+      "loc_over_m": "0"
+    }, {
+      "name": "Test Support",
+      "lines": "1",
+      "loc": "1",
+      "classes": "0",
+      "methods": "0",
+      "m_over_c": "0",
+      "loc_over_m": "0"
+    }, {
       "name": "Total",
-      "lines": "476",
-      "loc": "144",
-      "classes": "7",
+      "lines": "484",
+      "loc": "151",
+      "classes": "9",
       "methods": "1",
       "m_over_c": "0",
-      "loc_over_m": "142",
+      "loc_over_m": "149",
       "code_to_test_ratio": "0.0",
       "total": true
     }]


### PR DESCRIPTION
Hey,

This PR fixes https://github.com/fastruby/rails_stats/issues/11 by adding a dependency to `bundler-stats` and including a call to its CLI. 

Please check it out.

Thanks! 