### PR TITLE
[CHORE]: add CHANGELOG, Code of Conduct, and PR template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# main ([unreleased](https://github.com/fastruby/rails_stats/compare/v1.0.2...main))
+
+* [FEATURE: Add basic coverage to RailsStats::CodeStatistics#to_s](https://github.com/fastruby/rails_stats/pull/10)
+* [FEATURE: Enable simplecov and codecov](https://github.com/fastruby/rails_stats/pull/18)
+* [BUGFIX: Add methods for calculating M/C and LOC/M](https://github.com/fastruby/rails_stats/pull/19)
+* [FEATURE: Support JSON output](https://github.com/fastruby/rails_stats/pull/20)
+* [FEATURE: Add dependency on bundler-stats and improve output](https://github.com/fastruby/rails_stats/pull/21)
+
+
+# v1.0.2 / 2020-10-7 ([commits](https://github.com/fastruby/rails_stats/compare/v1.0.1...v1.0.2))
+
+* [CHORE: Relax bundler dependency to make it easier to get started contributing](https://github.com/fastruby/rails_stats/pull/9)
+
+# v1.0.1 / 2018-10-8
+
+* [FEATURE: add more aggregate stats](https://github.com/fastruby/rails_stats/pull/5)
+* [FEATURE: More detailed introspection of app](https://github.com/fastruby/rails_stats/pull/1)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at oss@ombulabs.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,9 @@
+**IMPORTANT**: Please read the README before submitting pull requests for this project. Additionally, if your PR closes any open GitHub issues, make sure you include _Closes #XXXX_ in your comment or use the option on the PR's sidebar to add related issues to auto-close the issue that your PR fixes.
+
+- [ ] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.
+
+**Description:**
+
+Please include a summary of the change and which issue is fixed or which feature is introduced. If changes to the behavior are made, clearly describe what changes.
+
+I will abide by the [code of conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Must have missed this one during the last sprint.

This PR adds everything in the title -- the PR template includes a reminder to update the CHANGELOG