### PR TITLE
Fix test by updating console output fixture

### DIFF
--- a/test/fixtures/console-output.txt
+++ b/test/fixtures/console-output.txt
@@ -1,8 +1,8 @@
 +-----------------------|------------|----------------+
 |                  Name | Total Deps | 1st Level Deps |
 +-----------------------|------------|----------------+
-|     simplecov-console | 7          | 3              |
-|               codecov | 5          | 2              |
+|     simplecov-console | 8          | 3              |
+|               codecov | 4          | 1              |
 |           rails_stats | 4          | 2              |
 |             simplecov | 3          | 3              |
 |       minitest-around | 1          | 1              |


### PR DESCRIPTION
- [ ] ~Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.~ (not done since this only affects the tests)

**Description:**

When checking out the repo and testing locally I was seeing a failure. It was due to a newer `simplecov-console` (v0.9.3) having an additional dependency.