### PR TITLE
Make diff output clear for test failures

### DIFF
--- a/test/lib/rails_stats/code_statistics_test.rb
+++ b/test/lib/rails_stats/code_statistics_test.rb
@@ -14,7 +14,7 @@ describe RailsStats::CodeStatistics do
         RailsStats::CodeStatistics.new(root_directory).to_s
       end
 
-      assert_equal table.delete(" \n"), out.delete(" \n")
+      assert_equal table, out
     end
   end
 end


### PR DESCRIPTION
- [ ] ~Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.~ N/A

The other CI issues will need to solved first, but this makes the failure output much easier to read, e.g.:

```
  1) Failure:
RailsStats::CodeStatistics::#to_s#test_0001_outputs useful stats for a Rails project [test/lib/rails_stats/code_statistics_test.rb:17]:
--- expected
+++ actual
@@ -4,9 +4,9 @@
 " +
 "+-----------------------|------------|----------------+
 " +
-"|     simplecov-console | 7          | 3              |
+"|     simplecov-console | 8          | 3              |
 " +
-"|               codecov | 5          | 2              |
+"|               codecov | 4          | 1              |
 " +
 "|           rails_stats | 4          | 2              |
 " +
@@ -24,17 +24,17 @@
 " +
 "+-----------------------|------------|----------------+
 " +
-"
+"
 " +
-"      Declared Gems   9
+"      Declared Gems   9
 " +
-"         Total Gems   18
+"         Total Gems   18
 " +
-"  Unpinned Versions   8
+"  Unpinned Versions   8
 " +
-"        Github Refs   0
+"        Github Refs   0
 " +
-"
+"
 " +
 "+----------------------+---------+---------+---------+---------+---------+-----+-------+
 " +
@@ -76,4 +76,7 @@
 " +
 "+----------------------+---------+---------+---------+---------+---------+-----+-------+
 " +
-"  Code LOC: 145     Test LOC: 6     Code to Test Ratio: 1:0.0  Files: 34"
+"  Code LOC: 145     Test LOC: 6     Code to Test Ratio: 1:0.0  Files: 34
+" +
+"
+"
```